### PR TITLE
Set minimum Python version to 3.7

### DIFF
--- a/.run/__main__.run.xml
+++ b/.run/__main__.run.xml
@@ -12,7 +12,7 @@
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="pybmtool" />
+    <option name="SCRIPT_NAME" value="bmtool" />
     <option name="PARAMETERS" value="component list -b d22ap -v 1 -u https://updates.cdn-apple.com/2022FCSWinter/patches/002-81327/3794B9A2-ED96-4243-9353-B8E27D876500/com_apple_MobileAsset_SoftwareUpdate/9a8a41e2a0f503295d619d66dc9eab1afbe09dc2.zip" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/Cryptiiiic/BMTool"
 bmtool = "pybmtool.__main__:cli"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.7"
 remotezip = "^0.9.4"
 click = "^8.1.3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/Cryptiiiic/BMTool"
 
 [tool.poetry.scripts]
-bmtool = "pybmtool.__main__:cli"
+pybmtool = "pybmtool.__main__:cli"
 
 [tool.poetry.dependencies]
 python = "^3.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/Cryptiiiic/BMTool"
 
 [tool.poetry.scripts]
-pybmtool = "pybmtool.__main__:cli"
+bmtool = "pybmtool.__main__:cli"
 
 [tool.poetry.dependencies]
 python = "^3.7"


### PR DESCRIPTION
Closes #3. This pull request also removes any references to a non-existent `pybmtool` script, which (for some reason) seems to be mentioned.